### PR TITLE
Smoothier transition for frame between different-width thumbnails

### DIFF
--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -59,7 +59,7 @@
 }
 
 %transition-for-touch {
-  transition-property: transform;
+  transition-property: transform, width;
   transition-timing-function: cubic-bezier(.1, 0, .25, 1);
   transition-duration: 0ms;
 }


### PR DESCRIPTION
Right now when you have thumbnails with different width and you switch between them, the frame takes the width of a new thumbnail momentarily. If you'd add a transition to width there, the switch would be a bit more visually smoothier.

However, if there are reasons not to have this transition, it's ok to close this PR :) Also, I'm not sure I placed the fix into the right place — the name of the placeholder confuses me a bit, however, it's fitting perfect for the goal, and there shouldn't be any side effects.
