### PR TITLE
Remove pointer-events from active and disabled things

### DIFF
--- a/src/scss/_arrows.scss
+++ b/src/scss/_arrows.scss
@@ -55,6 +55,7 @@ $arrSize: 32px;
   *display: none;
   filter: alpha(opacity=0);
   opacity: .1;
+  pointer-events: none;
 }
 
 .fotorama__fullscreen-icon {

--- a/src/scss/fotorama.scss
+++ b/src/scss/fotorama.scss
@@ -265,6 +265,8 @@ $time: 300ms;
 }
 
 .fotorama__nav__frame.fotorama__active {
+  pointer-events: none;
+
   .fotorama__dot {
     width: 6px;
     height: 6px;


### PR DESCRIPTION
1. Adding `pointer-events: none` for active thumb/dot makes two things: it fixes a very minor bug when clicking two pixels on the right of the thumbnail makes the thumbnails move a bit, and it makes the active dot not to have pointer cursor — as it's already chosen there is no point to have events on it (pun intended).
2. And adding `pointer-events: none` to the disabled arrow makes the cursor to propagate to the element below, right now there could be sometimes a default cursor over it instead of a grab one (and I think that `pointer-events` for disabled is a much more appropriate way instead of just cursor change).
