### PR TITLE
Added wordWrap()

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,11 +21,12 @@ meta: {
     'src/js/wheel.js',
     'src/js/fotorama.js',
     'src/js/fn-fotorama.js',
+    'src/js/wordwrap.js',
     'src/js/instances.js',
     'src/js/cache.js',
     'src/templates/compiled.js',
     'src/js/auto-initialization.js',
-    'src/js/outro.js'
+    'src/js/outro.js',
   ]
 },
 jst: {

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -591,7 +591,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
         }
 
         if (opts.captions && dataFrame.caption) {
-          $(div(captionClass, div(captionWrapClass, dataFrame.caption))).appendTo($frame);
+          $(div(captionClass, div(captionWrapClass, wordWrap(dataFrame.caption, that.options)))).appendTo($frame);
         }
 
         dataFrame.video && $frame

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -1,0 +1,27 @@
+  // This function will wrap the first x words in a p with class y,
+  // where x is option wrapword['count'] and y is option wrapword['wrapclass']
+  // The remaining text will be inserted into a paragraph with class wrapword['restclass']
+  function wordWrap(sentence, opts) {
+
+      if (opts['wrapword']) {
+
+          var phrase = "";
+
+          // Account for stupid whitespace
+          if (sentence.substring(0,1) == " ") {
+              sentence = sentence.slice(1);
+          }
+
+          for (i = 0; i < opts['wrapword']['count']; i++) {
+              phrase = phrase + " " + sentence.split(" ")[i];
+          }
+
+          var wrappedPhrase = '<p class="' + opts['wrapword']['wrapclass'] + '">' + phrase + '</p>';
+
+          sentence = sentence.slice(phrase.length);
+          sentence = '<p class="' + opts['wrapword']['restclass'] + '">' + sentence + '</p>';
+
+          sentence = wrappedPhrase + sentence;
+      }
+      return sentence;
+  }


### PR DESCRIPTION
wordWrap() will wrap the first x words in each image slide's caption.

Options available for count (# of words to wrap), wrapclass (CSS class
to give to the wrapped phrase) and restclass (CSS class to give to the
rest of the caption).

  wrapword: {
    count: 1,
    wrapclass: 'first-word',
    restclass: 'rest'
  }

This was helpful when using building Fotorama for the Wordpress plugin. See example screenshot below:
![Screenshot](https://f.cloud.github.com/assets/5681218/1409216/1469ac06-3d8f-11e3-8d0e-32dc18425129.png)
