### PR TITLE
Fix compatibility with `$.noConflict(true)`

### DIFF
--- a/src/js/outro.js
+++ b/src/js/outro.js
@@ -1,1 +1,1 @@
-})(window, document, location, window.jQuery);
+})(window, document, location, typeof jQuery !== 'undefined' && jQuery);


### PR DESCRIPTION
Replace: `window.jQuery` → `jQuery`

Rationale is well described here in https://github.com/twbs/bootstrap/issues/10038

TL;DR: `window.jQuery` breaks browserify/webpack/etc. `jQuery` doesn't.

Notes:
- it's a copy of https://github.com/daguej/bootstrap/commit/f140084f2beb17b0a266b42ab9a03d0b935e5f66
- it should not break https://github.com/artpolikarpov/fotorama/commit/58bfb2248b83098115422ef901ae58c6f8c2169b (Alert in console, that Fotorama requires jQuery 1.8)
