### PR TITLE
Fixed a typo that forced using the http protocol

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -129,7 +129,7 @@ function edgeResistance (pos, edge) {
 }
 
 function getProtocol () {
-  getProtocol.p = getProtocol.p || (location.protocol === 'https://' ? 'https://' : 'http://');
+  getProtocol.p = getProtocol.p || (location.protocol === 'https:' ? 'https://' : 'http://');
   return getProtocol.p;
 }
 


### PR DESCRIPTION
Videos (iframes) loaded with fotorama were blocked when initialized on a secure webpage (https).
