### PR TITLE
fix missing stage-control animation for 'crossfade/dissolve' transitions

### DIFF
--- a/src/scss/_arrows.scss
+++ b/src/scss/_arrows.scss
@@ -126,7 +126,7 @@
 }
 
 .fotorama__wrap--css3 {
-  &.fotorama__wrap--slide.fotorama__wrap--no-controls,
+  &.fotorama__wrap--slide.fotorama__wrap--no-controls, 
   &.fotorama__wrap--fade.fotorama__wrap--no-controls,
   &.fotorama__wrap--video {
     .fotorama__fullscreen-icon {

--- a/src/scss/fotorama.scss
+++ b/src/scss/fotorama.scss
@@ -291,6 +291,7 @@ $arrSize: 32px;
   left: 0;
   border-style: solid;
   border-color: mix(#00d1ff, #008ed6);
+  border-color: rgba(0, 175, 234,0.75);
   background-image: linear-gradient(to bottom right, rgba(255, 255, 255, .25), rgba(64, 64, 64, .1));
 }
 


### PR DESCRIPTION
Added the missing rule for non slide transitions. Non-Slide transitions still show stage-controls onload until hovered with the mouse. I suspect that there is a missing .hide() in the javascript for stage-controls with other transition effects.

Little detail, added an rgba thumb-border, as progressive-enhancement for supporting browsers.
