### PR TITLE
Make fotorama monolithic with z-index

### DIFF
--- a/src/scss/fotorama.scss
+++ b/src/scss/fotorama.scss
@@ -49,6 +49,7 @@ $arrSize: 32px;
   position: relative;
   @extend %no-select;
   direction: ltr;
+  z-index: 0;
 
   * {
      // /test/specs/thumbs.js


### PR DESCRIPTION
At the moment Fotorama elements (frames, arrows, thumbs) has different `z-indexes`, but Fotorama wrapper has not. Elements on host page with `z-index` between 0 and 8 can overlap one Fotorama elements and be overlapped by another.

![screen shot 2014-05-13 at 16 10 29](https://cloud.githubusercontent.com/assets/128982/2967651/08014d4c-db33-11e3-9b42-9d898916f6ed.jpg)

This fix makes Fotorama solid and monolithic by adding `z-index` to wrapper.
