### PR TITLE
correcting style.jst to use the generated js fotorama class names

### DIFF
--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -301,7 +301,17 @@ jQuery.Fotorama = function ($fotorama, opts) {
       $navFrame = $navThumbFrame;
       navFrameKey = NAV_THUMB_FRAME_KEY;
 
-      setStyle($style, $.Fotorama.jst.style({w: o_thumbSide, h: o_thumbSide2, b: opts.thumbborderwidth, m: opts.thumbmargin, s: stamp, q: !COMPAT}));
+      setStyle($style, $.Fotorama.jst.style({
+        w: o_thumbSide, 
+        h: o_thumbSide2, 
+        b: opts.thumbborderwidth, 
+        m: opts.thumbmargin, 
+        s: stampClass,
+        nt: navThumbsClass,
+        nf: navFrameClass,
+        tb: thumbBorderClass,
+        q: !COMPAT
+      }));
 
       $nav
           .addClass(navThumbsClass)

--- a/src/templates/style.jst
+++ b/src/templates/style.jst
@@ -1,7 +1,7 @@
-.fotorama<%= v.s %> .fotorama__nav--thumbs .fotorama__nav__frame{
+.<%= v.s %> .<%= v.nt %> .<%= v.nf %>{
 padding:<%= v.m %>px;
 height:<%= v.h %>px}
-.fotorama<%= v.s %> .fotorama__thumb-border{
+.<%= v.s %> .<%= v.tb %>{
 height:<%= v.h - v.b * (v.q ? 0 : 2) %>px;
 border-width:<%= v.b %>px;
 margin-top:<%= v.m %>px}


### PR DESCRIPTION
style.jst is using hardcoded ".fotorama*" class names.  These names are set in css-classes.js, so I updated the template call to utilize these variables instead.
