### PR TITLE
Using srcset attribute with images for more responsive (develop branch)

### DIFF
--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -561,6 +561,9 @@ jQuery.Fotorama = function ($fotorama, opts) {
 
       frameData.state = '';
       img.src = src;
+      if (dataFrame.srcset) {
+        img.srcset = dataFrame.srcset;
+      }
     });
   }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -235,6 +235,7 @@ function getDataFromHtml ($el) {
     var $child = $img.children('img').eq(0),
         _imgHref = $img.attr('href'),
         _imgSrc = $img.attr('src'),
+        _imgSrcset = $img.attr('srcset'),
         _thumbSrc = $child.attr('src'),
         _video = imgData.video,
         video = checkVideo ? findVideoId(_imgHref, _video === true) : false;
@@ -248,7 +249,8 @@ function getDataFromHtml ($el) {
     getDimensions($img, $child, $.extend(imgData, {
       video: video,
       img: imgData.img || _imgHref || _imgSrc || _thumbSrc,
-      thumb: imgData.thumb || _thumbSrc || _imgSrc || _imgHref
+      thumb: imgData.thumb || _thumbSrc || _imgSrc || _imgHref,
+      srcset: _imgSrcset
     }));
   }
 


### PR DESCRIPTION
This make possiple to use new img attribite "srcset". You can use it with thumbs or without.
Example with thumbs:
`<a href="img/large.jpg" srcset="img/large.jpg 1920w, img/medium.jpg 960w, img/little.jpg 480w">
    <img src="img/thumb.jpg">
</a>`
Example without thumbs:
`<img src="img/large.jpg" srcset="img/large.jpg 1920w, img/medium.jpg 960w, img/little.jpg 480w">`
