### PR TITLE
Add smart fit option

### DIFF
--- a/src/js/basevars.js
+++ b/src/js/basevars.js
@@ -56,6 +56,9 @@ var $WINDOW = $(window),
 
       fit: 'contain', // 'cover' || 'scaledown' || 'none'
 
+      smartfitpx: 1.5, // Maximum scaling of pixels in smart fit, eg: 100 px width maximum 150px scaled
+      smartfitthreshold: 0.75, // Threshold where smart fit scaling takes effect, 1 = exact, 0.75 = at least 75% cover the gallery area
+
       position: FIFTYFIFTY,
       thumbposition: FIFTYFIFTY,
 

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -506,7 +506,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
             .addClass(imgClass + (fullFLAG ? ' ' + imgFullClass : ''))
             .prependTo($frame);
 
-        fit($img, ($.isFunction(specialMeasures) ? specialMeasures() : specialMeasures) || measures, method || dataFrame.fit || opts.fit, position || dataFrame.position || opts.position);
+        fit($img, ($.isFunction(specialMeasures) ? specialMeasures() : specialMeasures) || measures, method || dataFrame.fit || opts.fit, position || dataFrame.position || opts.position, dataFrame.smartfitpx || opts.smartfitpx, dataFrame.smartfitthreshold || opts.smartfitthreshold);
 
         $.Fotorama.cache[src] = frameData.state = 'loaded';
 
@@ -647,8 +647,8 @@ jQuery.Fotorama = function ($fotorama, opts) {
     });
   }
 
-  function callFit ($img, measuresToFit, method, position) {
-    return $img && $img.length && fit($img, measuresToFit, method, position);
+  function callFit ($img, measuresToFit, method, position, smartfitPx, smartfitThreshold) {
+    return $img && $img.length && fit($img, measuresToFit, method, position, smartfitPx, smartfitThreshold);
   }
 
   function stageFramePosition (indexes) {
@@ -657,7 +657,9 @@ jQuery.Fotorama = function ($fotorama, opts) {
 
       var normalizedIndex = normalizeIndex(index),
           method = dataFrame.fit || opts.fit,
-          position = dataFrame.position || opts.position;
+          position = dataFrame.position || opts.position,
+          smartfitPx  = dataFrame.smartfitpx || opts.smartfitpx,
+          smartfitThreshold = dataFrame.smartfitthreshold || opts.smartfitthreshold;
       frameData.eq = normalizedIndex;
 
       toDetach[STAGE_FRAME_KEY][normalizedIndex] = $frame.css($.extend({left: o_fade ? 0 : getPosByIndex(index, measures.w, opts.margin, repositionIndex)}, o_fade && getDuration(0)));
@@ -667,8 +669,8 @@ jQuery.Fotorama = function ($fotorama, opts) {
         unloadVideo(dataFrame.$video);
       }
 
-      callFit(frameData.$img, measures, method, position);
-      callFit(frameData.$full, measures, method, position);
+      callFit(frameData.$img, measures, method, position, smartfitPx, smartfitThreshold);
+      callFit(frameData.$full, measures, method, position, smartfitPx, smartfitThreshold);
     });
   }
 
@@ -691,13 +693,15 @@ jQuery.Fotorama = function ($fotorama, opts) {
           specialMeasures = getSpecialMeasures(),
           dataFrame = data[eq] || {},
           method = dataFrame.thumbfit || opts.thumbfit,
-          position = dataFrame.thumbposition || opts.thumbposition;
+          position = dataFrame.thumbposition || opts.thumbposition,
+          smartfitPx  = dataFrame.smartfitpx || opts.smartfitpx,
+          smartfitThreshold = dataFrame.smartfitthreshold || opts.smartfitthreshold;
 
       specialMeasures.w = thisData.w;
 
       if (thisData.l + thisData.w < leftLimit
           || thisData.l > rightLimit
-          || callFit(thisData.$img, specialMeasures, method, position)) return;
+          || callFit(thisData.$img, specialMeasures, method, position, smartfitPx, smartfitThreshold)) return;
 
       loadFLAG && loadImg([eq], 'navThumb', getSpecialMeasures, method, position);
     });


### PR DESCRIPTION
Demo and explanation of functionality here: 

http://jsguy.com/fotorama/example/test01.htm

Description:

We had a problem. A seemingly unsolvable problem - many of the photos we have are not of the highest resolution, and quite a few are portrait instead of landscape, which is what our page design and gallery needs.

We tried the different ways of using the "fit" methods of fotorama, "scaledown" was too small, and the user would not be able to see the details, whereas "cover" made the photo too pixelated. The "contain" and "none" options were not suitable either.

The solution was to add a "smart" fit option - this uses "cover" by default, unless the image would be is scaled by a set pixel factor, at which point we use a scaled down "cover", but only up to the said pixel factor. This allows the best of both worlds: "cover" when the image has enough detail, and a scaled down "cover" for when it does not. 
