### PR TITLE
Vimeo support improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Important!** If you load Fotorama from S3, please switch to [cdnjs](https://cdnjs.com/libraries/fotorama)! Our S3 bucket will be killed on JAN 12.
+
 # Fotorama source
 
 There is nothing for non-coders. Take the latest and ready-to-use Fotorama on its website:<br>

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -172,7 +172,7 @@ function findVideoId (href, forceVideo) {
     type = 'youtube';
   } else if (href.host.match(/vimeo\.com/)) {
     type = 'vimeo';
-    id = href.pathname.replace(/^\/(video\/)?/, '').replace(/\/.*/, '');
+    id = href.pathname.replace(/^\/(\w+\/)*/, '').replace(/\/.*/, '');
   }
 
   if ((!id || !type) && forceVideo) {
@@ -190,14 +190,13 @@ function getVideoThumbs (dataFrame, data, fotorama) {
     img = thumb.replace(/\/default.jpg$/, '/hqdefault.jpg');
     dataFrame.thumbsReady = true;
   } else if (video.type === 'vimeo') {
-    $.ajax({
-      url: getProtocol() + 'vimeo.com/api/v2/video/' + video.id + '.json',
-      dataType: 'jsonp',
-      success: function (json) {
+    $.getJSON(getProtocol() + 'vimeo.com/api/oembed.json',
+      {url: 'http://vimeo.com/' + video.id},
+      function (json) {
         dataFrame.thumbsReady = true;
-        updateData(data, {img: json[0].thumbnail_large, thumb: json[0].thumbnail_small}, dataFrame.i, fotorama);
+        updateData(data, {img: json.thumbnail_url, thumb: json.thumbnail_url}, dataFrame.i, fotorama);
       }
-    });
+    );
   } else {
     dataFrame.thumbsReady = true;
   }


### PR DESCRIPTION
1. Некоторые видео Vimeo (например https://vimeo.com/ondemand/aiweiwei/105881175). Исправленная регулярка в `findVideoId()` теперь правильно вынимает `id` таких видео.

2. Используемый старый API (v2) не позволяет получить информацию на некоторые видео (пруф http://vimeo.com/api/v2/video/105881175.json). Почитать об этом можно здесь: http://vimeo.com/forums/topic:47382 Рекомендуется использовать новый [oEmbed API](https://developer.vimeo.com/apis/oembed) и это работает (и так http://vimeo.com/api/oembed.json?url=https://vimeo.com/ondemand/aiweiwei/105881175 и так http://vimeo.com/api/oembed.json?url=https://vimeo.com/105881175). Единственный недостаток, то что не приходит `thumbnail_small`.