### PR TITLE
Absolutely positioned navigation

### DIFF
--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -1239,7 +1239,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
     var width = measures.width,
         height = measures.height,
         ratio = measures.ratio,
-        windowHeight = $WINDOW.height() - (o_nav ? $nav.height() : 0);
+        windowHeight = $WINDOW.height() - (o_nav && $nav.css('position') != 'absolute' && $nav.css('position') != 'fixed' ? $nav.height() : 0);
 
     if (measureIsValid(width)) {
       $wrap


### PR DESCRIPTION
This modification will be useful, if you have an absolutely positioned thumbnail or dot navigation. E.g. you want to put your navigation over the entire gallery (especially in fullscreen mode) or/and show the navigation on hover.

BR