### PR TITLE
 Add option `fullfit`: custom fit for fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Important!** If you load Fotorama from S3, please switch to [cdnjs](https://cdnjs.com/libraries/fotorama)! Our S3 bucket will be killed on JAN 12.
+
 # Fotorama source
 
 There is nothing for non-coders. Take the latest and ready-to-use Fotorama on its website:<br>

--- a/src/js/basevars.js
+++ b/src/js/basevars.js
@@ -70,6 +70,7 @@ var $WINDOW = $(window),
       thumbfit: 'cover', // 'contain' || 'scaledown' || 'none'
 
       allowfullscreen: false, // true || 'native'
+      fullfit: 'contain', // 'cover' || 'scaledown' || 'none'
 
       transition: 'slide', // 'crossfade' || 'dissolve'
       clicktransition: null,

--- a/src/js/basevars.js
+++ b/src/js/basevars.js
@@ -70,7 +70,7 @@ var $WINDOW = $(window),
       thumbfit: 'cover', // 'contain' || 'scaledown' || 'none'
 
       allowfullscreen: false, // true || 'native'
-      fullfit: 'contain', // 'cover' || 'scaledown' || 'none'
+      fullfit: false, // 'contain' || 'cover' || 'scaledown' || 'none'
 
       transition: 'slide', // 'crossfade' || 'dissolve'
       clicktransition: null,

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -506,7 +506,8 @@ jQuery.Fotorama = function ($fotorama, opts) {
             .addClass(imgClass + (fullFLAG ? ' ' + imgFullClass : ''))
             .prependTo($frame);
 
-        fit($img, ($.isFunction(specialMeasures) ? specialMeasures() : specialMeasures) || measures, method || dataFrame.fit || opts.fit, position || dataFrame.position || opts.position);
+        method = method || (that.fullScreen ? dataFrame.fullfit || opts.fullfit : dataFrame.fit || opts.fit)
+        fit($img, ($.isFunction(specialMeasures) ? specialMeasures() : specialMeasures) || measures, method, position || dataFrame.position || opts.position);
 
         $.Fotorama.cache[src] = frameData.state = 'loaded';
 
@@ -656,7 +657,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
       if (!$frame) return;
 
       var normalizedIndex = normalizeIndex(index),
-          method = dataFrame.fit || opts.fit,
+          method = (that.fullScreen ? dataFrame.fullfit || opts.fullfit : dataFrame.fit || opts.fit),
           position = dataFrame.position || opts.position;
       frameData.eq = normalizedIndex;
 

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -506,7 +506,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
             .addClass(imgClass + (fullFLAG ? ' ' + imgFullClass : ''))
             .prependTo($frame);
 
-        method = method || (that.fullScreen ? dataFrame.fullfit || opts.fullfit : dataFrame.fit || opts.fit)
+        method = method || (that.fullScreen  && opts.fullfit ? dataFrame.fullfit || opts.fullfit : dataFrame.fit || opts.fit)
         fit($img, ($.isFunction(specialMeasures) ? specialMeasures() : specialMeasures) || measures, method, position || dataFrame.position || opts.position);
 
         $.Fotorama.cache[src] = frameData.state = 'loaded';
@@ -657,7 +657,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
       if (!$frame) return;
 
       var normalizedIndex = normalizeIndex(index),
-          method = (that.fullScreen ? dataFrame.fullfit || opts.fullfit : dataFrame.fit || opts.fit),
+          method = (that.fullScreen && opts.fullfit ? dataFrame.fullfit || opts.fullfit : dataFrame.fit || opts.fit),
           position = dataFrame.position || opts.position;
       frameData.eq = normalizedIndex;
 


### PR DESCRIPTION
The options of `fullfit` resemble the same options for `fit` and `thumbfit` plus an additional default value `false` for backward compatiblity, in which case fitting behaves like before.

Separating control over the fullscreen fitting method from the main slideshow window is useful, if the website layout would suffer from unexpected image sizes within the main slideshow window (i.e. ugly borders), but should be fully contained within fullscreen (e.g. for the presentation of products). Especially, if you have no control over the image sizes (e.g. plugin for framework), this option might come in handy.
