### PR TITLE
Comment out `console.log`

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -341,7 +341,7 @@ function fit ($el, measuresToFit, method, position) {
       elData.l.m !== method ||
       elData.l.p !== position)) {
 
-    console.log('fit');
+    //console.log('fit');
 
     var width = measures.width,
         height = measures.height,


### PR DESCRIPTION
Stops Fotorama from logging its internal stuff to console.

![image](https://cloud.githubusercontent.com/assets/1530865/6885567/2644fb72-d62e-11e4-86eb-74b7f96284bc.png)
