### PR TITLE
Fix incompatible fotoramaVersion definition.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ grunt.initConfig({
 pkg: grunt.file.readJSON('package.json'),
 meta: {
   banner: '/*!\n * <%= pkg.name %> <%= pkg.version %> | http://fotorama.io/license/\n */\n',
-  bannerJs: '<%= meta.banner %>fotoramaVersion = \'<%= pkg.version %>\';\n',
+  bannerJs: '<%= meta.banner %>var fotoramaVersion = \'<%= pkg.version %>\';\n',
   sass: ['src/scss/*'],
   js: [
     'src/js/intro.js',


### PR DESCRIPTION
I ran into this error: "Uncaught ReferenceError: fotoramaVersion is not defined" at this line:
`fotoramaVersion = '4.6.3';`

This change should change that into:
`var fotoramaVersion = '4.6.3';`
