### PR TITLE
Change handling of portrait images

### DIFF
--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -418,7 +418,9 @@ jQuery.Fotorama = function ($fotorama, opts) {
       height = measureIsValid(opts.height) || measureIsValid(height) || HEIGHT;
       that.resize({
         width: width,
-        ratio: opts.ratio || ratio || width / height
+        height: height,
+        ratio: opts.ratio || ratio || width / height,
+        fit: opts.fit  // added 'fit' so we can determine best way to resize 
       }, 0, index !== startIndex && '*');
     }
   }
@@ -1239,6 +1241,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
     var width = measures.width,
         height = measures.height,
         ratio = measures.ratio,
+        scaledown = options && options.fit === 'scaledown',
         windowHeight = $WINDOW.height() - (o_nav ? $nav.height() : 0);
 
     if (measureIsValid(width)) {
@@ -1261,7 +1264,14 @@ jQuery.Fotorama = function ($fotorama, opts) {
 
       height = numberFromWhatever(height, windowHeight);
 
-      height = height || (ratio && width / ratio);
+      if (scaledown && ratio) {
+    	  // use the minimal height
+    	  height = Math.min(height, width / ratio);
+      }
+      else if (!scaledown && ratio) {
+    	  // always use scaled height
+    	  height = width / ratio;
+      }
 
       if (height) {
         width = Math.round(width);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -341,7 +341,7 @@ function fit ($el, measuresToFit, method, position) {
       elData.l.m !== method ||
       elData.l.p !== position)) {
 
-    console.log('fit');
+    //console.log('fit');
 
     var width = measures.width,
         height = measures.height,
@@ -354,7 +354,13 @@ function fit ($el, measuresToFit, method, position) {
 
     if (biggerRatioFLAG && (fitFLAG || containFLAG) || !biggerRatioFLAG && coverFLAG) {
       width = minMaxLimit(measuresToFit.w, 0, fitFLAG ? width : Infinity);
-      height = width / measures.ratio;
+      if (fitFLAG && measures.ratio < 1 && measuresToFit.w >= measures.width) {
+    	  // portrait image in scaledown mode
+    	  // keep height as ratio of scaled width
+      }
+      else {
+    	  height = width / measures.ratio;
+      }
     } else if (biggerRatioFLAG && coverFLAG || !biggerRatioFLAG && (fitFLAG || containFLAG)) {
       height = minMaxLimit(measuresToFit.h, 0, fitFLAG ? height : Infinity);
       width = height * measures.ratio;


### PR DESCRIPTION
Especially for portrait images, the way fotorama handles resizing of the wrapper is not how I want it to work. I therefore changed this to include the height and fit mode in the that.resize function, and the way the height is set in the fit function. Now in scale down mode and cover mode (the two modes I use and tested) the wrapper will never be higher than the original height of the first image, therefore will never create  extra space above and below the image.
