### PR TITLE
Fix for video restart on resize or fullscreen

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,14 @@
 
 ## 4.6.3, 31 December 2014
 
+<!--4.6.4:name-->
+Dummy
+<!--/4.6.4:name-->
+
+<!--4.6.4:notes-->
+Just to fix npm & bower packages.
+<!--/4.6.4:notes-->
+
 <!--4.6.3:name-->
 HPPNWYR
 <!--/4.6.3:name-->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Important!** If you load Fotorama from S3, please switch to [cdnjs](https://cdnjs.com/libraries/fotorama)! Our S3 bucket will be killed on JAN 12.
+
 # Fotorama source
 
 There is nothing for non-coders. Take the latest and ready-to-use Fotorama on its website:<br>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**Important!** If you load Fotorama from S3, please switch to [cdnjs](https://cdnjs.com/libraries/fotorama)! Our S3 bucket will be killed on JAN 12.
-
 # Fotorama source
 
 There is nothing for non-coders. Take the latest and ready-to-use Fotorama on its website:<br>

--- a/fotorama.jquery.json
+++ b/fotorama.jquery.json
@@ -1,6 +1,6 @@
 {
 	"name": "fotorama",
-	"version": "4.6.3",
+	"version": "4.6.4",
 	"title": "Fotorama",
 	"description": "A simple, stunning, powerful jQuery gallery.",
 	"filename": "fotorama.js",
@@ -29,7 +29,7 @@
 	"bugs": "https://github.com/artpolikarpov/fotorama/issues",
 	"homepage": "http://fotorama.io/",
 	"docs": "http://fotorama.io/set-up/",
-	"download": "https://github.com/artpolikarpov/fotorama/releases/download/4.6.3/fotorama-4.6.3.zip",
+	"download": "https://github.com/artpolikarpov/fotorama/releases/download/4.6.4/fotorama-4.6.4.zip",
 	"dependencies": {
 		"jquery": ">=1.8"
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Fotorama",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/artpolikarpov/fotorama.git"

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -663,7 +663,9 @@ jQuery.Fotorama = function ($fotorama, opts) {
       toDetach[STAGE_FRAME_KEY][normalizedIndex] = $frame.css($.extend({left: o_fade ? 0 : getPosByIndex(index, measures.w, opts.margin, repositionIndex)}, o_fade && getDuration(0)));
 
       if (isDetached($frame[0])) {
-        $frame.appendTo($stageShaft);
+        if ($stageShaft[0] !== $frame.parent()[0]) {
+          $frame.appendTo($stageShaft);
+        }  
         unloadVideo(dataFrame.$video);
       }
 


### PR DESCRIPTION
I have youtube video on page, and when page is resized or I try to go fullscreen, video is resized to original size and starts from the beginning.
Because of this I was unable to open video fullscreen at all.
It seems that constant re-inserting is not good when element is already in right place, so I decided to add simple check there and it works fine now.
