### PR TITLE
Fix IE8 black screen on close youtube video

### DIFF
--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -1376,6 +1376,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
     }
 
     if ($video && $video !== $videoPlaying) {
+      $video.hide();
       $video.remove();
       triggerEvent('unloadvideo');
     }


### PR DESCRIPTION
According to #224

I have the same problem in IE8. 
I found the solution at http://stackoverflow.com/questions/7452387/black-screen-when-removing-an-embedded-youtube-video-by-javascript-in-ie8
