### PR TITLE
Fix/ios8.4.1+crash

### DIFF
--- a/src/js/animate.js
+++ b/src/js/animate.js
@@ -1,4 +1,7 @@
 function slide ($el, options) {
+  if (isMobileDeviceZoomed()) {
+    return;
+  }
   var elData = $el.data(),
       elPos = Math.round(options.pos),
       onEndFn = function () {
@@ -34,6 +37,9 @@ function slide ($el, options) {
 }
 
 function fade ($el1, $el2, $frames, options, fadeStack, chain) {
+  if (isMobileDeviceZoomed()) {
+    return;
+  }
   var chainedFLAG = typeof chain !== 'undefined';
   if (!chainedFLAG) {
     fadeStack.push(arguments);

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -144,7 +144,8 @@ jQuery.Fotorama = function ($fotorama, opts) {
     var keydownCommon = 'keydown.' + _fotoramaClass,
         localStamp = _fotoramaClass + stamp,
         keydownLocal = 'keydown.' + localStamp,
-        resizeLocal = 'resize.' + localStamp + ' ' + 'orientationchange.' + localStamp;
+        resizeLocal = 'resize.' + localStamp,
+        orientationChangeLocal = 'orientationchange.' + localStamp;
 
     if (FLAG) {
       $DOCUMENT
@@ -181,12 +182,28 @@ jQuery.Fotorama = function ($fotorama, opts) {
               !$BODY.hasClass(_fullscreenClass) && e.stopPropagation();
             });
       }
-
-      $WINDOW.on(resizeLocal, that.resize);
+      if (!isTouchDevice()) {
+        $WINDOW.on(resizeLocal, that.resize);
+      } else {
+        $WINDOW.on(orientationChangeLocal, that.resize);
+      }
     } else {
       $DOCUMENT.off(keydownLocal);
-      $WINDOW.off(resizeLocal);
+      if (!isTouchDevice()) {
+        $WINDOW.off(resizeLocal);
+      } else {
+        $WINDOW.off(orientationChangeLocal);
+      }
     }
+  }
+
+  function isTouchDevice() {
+    var result = 'ontouchstart' in window || window.navigator.msMaxTouchPoints;
+
+    isTouchDevice = function() {
+        return result;
+    };
+    return result;
   }
 
   function appendElements (FLAG) {
@@ -900,6 +917,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
   }
 
   function onTouchStart () {
+    if (isMobileDeviceZoomed()) return;
     clearTimeout(onTouchEnd.t);
     touchedFLAG = 1;
 
@@ -911,7 +929,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
   }
 
   function onTouchEnd () {
-    if (!touchedFLAG) return;
+    if (!touchedFLAG || isMobileDeviceZoomed()) return;
     if (!opts.stopautoplayontouch) {
       releaseAutoplay();
       changeAutoplay();
@@ -1403,7 +1421,9 @@ jQuery.Fotorama = function ($fotorama, opts) {
     }
   }
 
-  $stage.on('mousemove', stageCursor);
+  if (!isTouchDevice()) {
+    $stage.on('mousemove', stageCursor);
+  }
 
   function clickToShow (showOptions) {
     clearTimeout(clickToShow.t);
@@ -1459,12 +1479,12 @@ jQuery.Fotorama = function ($fotorama, opts) {
   stageShaftTouchTail = moveOnTouch($stageShaft, {
     onStart: onTouchStart,
     onMove: function (e, result) {
-      setShadow($stage, result.edge);
+      //setShadow($stage, result.edge);
     },
     onTouchEnd: onTouchEnd,
     onEnd: function (result) {
       ////console.time('stageShaftTouchTail.onEnd');
-      setShadow($stage);
+      //setShadow($stage);
 
       ////console.log('result', result);
 
@@ -1497,7 +1517,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
   navShaftTouchTail = moveOnTouch($navShaft, {
     onStart: onTouchStart,
     onMove: function (e, result) {
-      setShadow($nav, result.edge);
+      //setShadow($nav, result.edge);
     },
     onTouchEnd: onTouchEnd,
     onEnd: function (result) {

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -1479,12 +1479,12 @@ jQuery.Fotorama = function ($fotorama, opts) {
   stageShaftTouchTail = moveOnTouch($stageShaft, {
     onStart: onTouchStart,
     onMove: function (e, result) {
-      //setShadow($stage, result.edge);
+      setShadow($stage, result.edge);
     },
     onTouchEnd: onTouchEnd,
     onEnd: function (result) {
       ////console.time('stageShaftTouchTail.onEnd');
-      //setShadow($stage);
+      setShadow($stage);
 
       ////console.log('result', result);
 
@@ -1517,7 +1517,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
   navShaftTouchTail = moveOnTouch($navShaft, {
     onStart: onTouchStart,
     onMove: function (e, result) {
-      //setShadow($nav, result.edge);
+      setShadow($nav, result.edge);
     },
     onTouchEnd: onTouchEnd,
     onEnd: function (result) {

--- a/src/js/moveontouch.js
+++ b/src/js/moveontouch.js
@@ -33,6 +33,9 @@ function moveOnTouch ($el, options) {
   }
 
   function onStart (e, result) {
+    if (isMobileDeviceZoomed()) {
+      return;
+    }
     min = tail.min;
     max = tail.max;
     snap = tail.snap;
@@ -48,6 +51,9 @@ function moveOnTouch ($el, options) {
   }
 
   function onMove (e, result) {
+    if (isMobileDeviceZoomed()) {
+      return;
+    }
     if (!tail.noSwipe) {
       if (!tracked) {
         startTracking(e);
@@ -81,6 +87,9 @@ function moveOnTouch ($el, options) {
   }
 
   function onEnd (result) {
+    if (isMobileDeviceZoomed()) {
+      return;
+    }
     ////console.time('moveontouch.js onEnd');
     if (tail.noSwipe && result.moved) return;
 

--- a/src/js/touch.js
+++ b/src/js/touch.js
@@ -24,6 +24,9 @@ function touch ($el, options) {
       moved;
 
   function onStart (e) {
+    if (isMobileDeviceZoomed()) {
+      return;
+    }
     $target = $(e.target);
     tail.checked = targetIsSelectFLAG = targetIsLinkFlag = moved = false;
 
@@ -53,6 +56,9 @@ function touch ($el, options) {
   }
 
   function onMove (e) {
+    if (isMobileDeviceZoomed()) {
+      return;
+    }
     if ((e.touches && e.touches.length > 1)
         || (MS_POINTER && !e.isPrimary)
         || moveEventType !== e.type
@@ -88,6 +94,9 @@ function touch ($el, options) {
   }
 
   function onEnd (e) {
+    if (isMobileDeviceZoomed()) {
+      return;
+    }
     ////console.time('touch.js onEnd');
 
     (options.onTouchEnd || noop)();
@@ -141,12 +150,14 @@ function touch ($el, options) {
     addEvent(document, 'touchend', onOtherEnd);
     addEvent(document, 'touchcancel', onOtherEnd);
 
-    $WINDOW.on('scroll', onOtherEnd);
-
-    $el.on('mousedown', onStart);
-    $DOCUMENT
+    if (!isTouchDevice()) {
+      $WINDOW.on('scroll', onOtherEnd);
+      $el.on('mousedown', onStart);
+      $DOCUMENT
         .on('mousemove', onMove)
         .on('mouseup', onEnd);
+    }
+
   }
 
   $el.on('click', 'a', function (e) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -18,7 +18,7 @@ function readPosition ($el) {
 
 function getTranslate (pos/*, _001*/) {
   var obj = {};
-  if (CSS3) {
+  if (CSS3 && !isTouchDevice()) {
     obj.transform = 'translate3d(' + (pos/* + (_001 ? 0.001 : 0)*/) + 'px,0,0)'; // 0.001 to remove Retina artifacts
   } else {
     obj.left = pos;

--- a/src/js/wheel.js
+++ b/src/js/wheel.js
@@ -1,3 +1,7 @@
+var isMobileDeviceZoomed = function() {
+    return isTouchDevice() && document.documentElement.clientWidth / window.innerWidth != 1;
+};
+
 function wheel ($el, options) {
   var el = $el[0],
       lockFLAG,
@@ -8,6 +12,9 @@ function wheel ($el, options) {
       };
 
   addEvent(el, WHEEL, function (e) {
+    if (isMobileDeviceZoomed()) {
+      return;
+    }
     var yDelta = e.wheelDeltaY || -1 * e.deltaY || 0,
         xDelta = e.wheelDeltaX || -1 * e.deltaX || 0,
         xWin = Math.abs(xDelta) && !Math.abs(yDelta),

--- a/test/i/index.html
+++ b/test/i/index.html
@@ -5,7 +5,6 @@
 <h1>Index of ./test/i</h1>
 <ul>
 <li><a href="../">../</a></li>
-<li><a href=".DS_Store">.DS_Store</a></li>
 <li><a href="dailymotion/">dailymotion/</a></li>
 <li><a href="fit/">fit/</a></li>
 <li><a href="flowplayer/">flowplayer/</a></li>

--- a/test/i/okonechnikov/index.html
+++ b/test/i/okonechnikov/index.html
@@ -5,7 +5,6 @@
 <h1>Index of ./test/i/okonechnikov</h1>
 <ul>
 <li><a href="../">../</a></li>
-<li><a href=".DS_Store">.DS_Store</a></li>
 <li><a href="1-lo.jpg">1-lo.jpg</a></li>
 <li><a href="1-thumb.jpg">1-thumb.jpg</a></li>
 <li><a href="1.jpg">1.jpg</a></li>

--- a/test/index.html
+++ b/test/index.html
@@ -6,7 +6,6 @@
 <ul>
 <li><a href="#119/">#119/</a></li>
 <li><a href="../">../</a></li>
-<li><a href=".DS_Store">.DS_Store</a></li>
 <li><a href="__base.html">__base.html</a></li>
 <li><a href="_show12.html">_show12.html</a></li>
 <li><a href="additional-nav-bar.html">additional-nav-bar.html</a></li>


### PR DESCRIPTION
When you are zooming in and out quickly and dragging the webpage while zoomed in, it can crash from all the events it should handle.. resize is called every time you zoom.

Another thing is that -webkit-transform: translateZ can also crash it, I couldn't fix that here since it's added via the autoprefixer. 

Works fine in iOs9 though