### PR TITLE
fix in setMeasures, combined with thumbnails without set gallery dime…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ grunt.initConfig({
 pkg: grunt.file.readJSON('package.json'),
 meta: {
   banner: '/*!\n * <%= pkg.name %> <%= pkg.version %> | http://fotorama.io/license/\n */\n',
-  bannerJs: '<%= meta.banner %>fotoramaVersion = \'<%= pkg.version %>\';\n',
+  bannerJs: '<%= meta.banner %>var fotoramaVersion = \'<%= pkg.version %>\';\n',
   sass: ['src/scss/*'],
   js: [
     'src/js/intro.js',

--- a/fotorama.jquery.json
+++ b/fotorama.jquery.json
@@ -1,6 +1,6 @@
 {
 	"name": "fotorama",
-	"version": "4.6.4",
+	"version": "4.6.4a",
 	"title": "Fotorama",
 	"description": "A simple, stunning, powerful jQuery gallery.",
 	"filename": "fotorama.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Fotorama",
-  "version": "4.6.4",
+  "version": "4.6.4a",
   "repository": {
     "type": "git",
     "url": "https://github.com/artpolikarpov/fotorama.git"

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -409,8 +409,8 @@ jQuery.Fotorama = function ($fotorama, opts) {
     });
   }
 
-  function setMeasures (width, height, ratio, index) {
-    if (!measuresSetFLAG || (measuresSetFLAG === '*' && index === startIndex)) {
+  function setMeasures (width, height, ratio, index, type) {
+    if (type !== 'navThumb' && (!measuresSetFLAG || (measuresSetFLAG === '*' && index === startIndex))) {
 
       ////console.log('setMeasures', index, opts.width, opts.height);
 
@@ -499,7 +499,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
           ratio: img.width / img.height
         };
 
-        setMeasures(imgData.measures.width, imgData.measures.height, imgData.measures.ratio, index);
+        setMeasures(imgData.measures.width, imgData.measures.height, imgData.measures.ratio, index, type);
 
         $img
             .off('load error')

--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -561,6 +561,9 @@ jQuery.Fotorama = function ($fotorama, opts) {
 
       frameData.state = '';
       img.src = src;
+      if (dataFrame.srcset) {
+        img.srcset = dataFrame.srcset;
+      }      
     });
   }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -235,6 +235,7 @@ function getDataFromHtml ($el) {
     var $child = $img.children('img').eq(0),
         _imgHref = $img.attr('href'),
         _imgSrc = $img.attr('src'),
+        _imgSrcset = $img.attr('srcset'),
         _thumbSrc = $child.attr('src'),
         _video = imgData.video,
         video = checkVideo ? findVideoId(_imgHref, _video === true) : false;
@@ -248,7 +249,8 @@ function getDataFromHtml ($el) {
     getDimensions($img, $child, $.extend(imgData, {
       video: video,
       img: imgData.img || _imgHref || _imgSrc || _thumbSrc,
-      thumb: imgData.thumb || _thumbSrc || _imgSrc || _imgHref
+      thumb: imgData.thumb || _thumbSrc || _imgSrc || _imgHref,
+      srcset: _imgSrcset
     }));
   }
 


### PR DESCRIPTION
When using the gallery with thumbnails, the gallery was sometimes displayed correctly. Meaning the gallery got resized to the available width. Most of the times however, the gallery got resized to the width of a thumbnail. 

It turned out, that whether it workes or not depended whether the thumb or main index-0 pic was returned from the server first.

This change does fix this problem.
