### PR TITLE
Fix sub-pixel rounding errors on % width fotoramas

### DIFF
--- a/src/scss/fotorama.scss
+++ b/src/scss/fotorama.scss
@@ -371,7 +371,6 @@ $blue: mix(#00d1ff, #008ed6);
     animation: spinner 24s infinite linear;
     @extend %gpu;
   }
-  .fotorama__stage,
   .fotorama__nav,
   .fotorama__stage__frame
   {


### PR DESCRIPTION
There's no advantage to GPU-accelerating the stage, as this element isn't animating. 
Does this removes the subpixel rounding errors which will happen on percentage width GPU-accelerated elements on Chrome & Firefox.