### PR TITLE
Image Smooth fadeIn transition after loading fixed

### DIFF
--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -510,11 +510,16 @@ jQuery.Fotorama = function ($fotorama, opts) {
 
         $.Fotorama.cache[src] = frameData.state = 'loaded';
 
-        setTimeout(function () {
+        (window.requestAnimationFrame || setTimeout)(function () {
           $frame
               .trigger('f:load')
-              .removeClass(loadingClass + ' ' + errorClass)
-              .addClass(loadedClass + ' ' + (fullFLAG ? loadedFullClass : loadedImgClass));
+              .removeClass(loadingClass + ' ' + errorClass);
+
+          function addLoadedClass() {
+            $frame.addClass(loadedClass + ' ' + (fullFLAG ? loadedFullClass : loadedImgClass));
+          }
+
+          (window.requestAnimationFrame || setTimeout)(addLoadedClass, 0);
 
           if (type === 'stage') {
             triggerTriggerEvent('load');


### PR DESCRIPTION
Иногда транзишена не происходит, так как после загрузки картинки и добавления классов для фрейма все операции происходят внутри текущего анимационного кадра браузера. Чтобы картинка плавно появлялась добавляем классы для фрейма в конце текущего кадра анимации.
На всякий случай оставлен фоллбек в виде <code>(window.requestAnimationFrame || setTimeout)()</code> если вдруг в браузере нет функции <code>requestAnimationFrame</code>.