### PR TITLE
Fullscreen cancel should use native api cancel only if native option used

### DIFF
--- a/src/js/fotorama.js
+++ b/src/js/fotorama.js
@@ -1182,7 +1182,7 @@ jQuery.Fotorama = function ($fotorama, opts) {
     if (that.fullScreen) {
       that.fullScreen = false;
 
-      if (FULLSCREEN) {
+      if (o_nativeFullScreen && FULLSCREEN) {
         fullScreenApi.cancel(fotorama);
       }
 


### PR DESCRIPTION
This change checks only calls fullscreenAPI.cancel if fotorama was initialized with the allowfullscreen "native" option. 

This solves the following issue:

REPRO STEPS
1. Add fotorama to web page using allowfullscreen: true option (do not use "native" option)
2. Open the web page containing a fotorama viewer in any modern browser
3. Enter browser fullscreen mode (not fotorama)
4. Interact with fotorama gallery to put fotorama into fullscreen view
5. Exit fotorama fullscreen view

ACTUAL
Fotorama fullscreen mode is exited, but the web page is kicked out of native fullscreen mode as well. The browser is no longer in fullscreen mode.

EXPECTED
Fotorama should exit fullscreen but not kick the containing web page out of native fullscreen mode.
