### PR TITLE
Update utils.js: Support `passive` option

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -499,7 +499,12 @@ function getRatio (_ratio) {
 
 function addEvent (el, e, fn, bool) {
   if (!e) return;
-  el.addEventListener ? el.addEventListener(e, fn, !!bool) : el.attachEvent('on'+e, fn);
+  var supportsPassive = false;
+  try {
+    document.addEventListener('test', null, {get passive() {supportsPassive = true}});
+  } catch(err) {}
+  var opt = (supportsPassive) ? {passive: true} : !!bool;
+  el.addEventListener ? el.addEventListener(e, fn, opt) : el.attachEvent('on'+e, fn);
 }
 
 function elIsDisabled (el) {


### PR DESCRIPTION
To avoid `non-passive event listener` warning in Chrome or other modern browsers.
Related issue: #529 
Ref. https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener